### PR TITLE
Update Deploy Ghost Theme to v1.2.1

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
-      - uses: TryGhost/action-deploy-theme@v1.2.0
+      - name: Deploy Ghost Theme
+        uses: TryGhost/action-deploy-theme@v1.2.1
         with:
           api-url: ${{ secrets.GHOST_ADMIN_API_URL }}
           api-key: ${{ secrets.GHOST_ADMIN_API_KEY }}


### PR DESCRIPTION
Updated to the latest version, check the [GitHub Action](https://github.com/marketplace/actions/deploy-ghost-theme) page.